### PR TITLE
Corrects root folder path normalization

### DIFF
--- a/includes/API/DownloadService.php
+++ b/includes/API/DownloadService.php
@@ -45,11 +45,12 @@ class DownloadService
             wp_die(esc_html__('Invalid file path.', 'rrze-faubox'), 400);
         }
 
-        $rootFolder = get_option('rrze_faubox_folder', '');
-        if (empty($rootFolder)) {
+        $rootFolder = (string)get_option('rrze_faubox_folder', '');
+        if ($rootFolder === '') {
             wp_die(esc_html__('No folder configured.', 'rrze-faubox'), 403);
         }
-        $normalizedRoot = '/webdav/' . trim($rootFolder, '/') . '/';
+        $rootFolder = trim($rootFolder, '/');
+        $normalizedRoot = '/webdav/' . ($rootFolder !== '' ? $rootFolder . '/' : '');
         if (!str_starts_with($filePath, $normalizedRoot)) {
             wp_die(esc_html__('Access denied.', 'rrze-faubox'), 403);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rrze-faubox",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: files, cloud, fau, faubox, webdav, directory, list, table
 Requires at least: 6.8
 Tested up to: 7.0
 Requires PHP: 8.2
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: rrze
 Tags: files, cloud, fau, faubox, webdav, directory, list, table
 Requires at least: 6.8
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/rrze-faubox.php
+++ b/rrze-faubox.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name:        RRZE FAUbox
  * Plugin URI:         https://github.com/RRZE-Webteam/rrze-faubox
- * Version:            1.0.1
+ * Version:            1.0.2
  * Description:        A Plugin for FAUbox data integration
  * Author:             RRZE Webteam
  * Author URI:         https://www.wp.rrze.fau.de/

--- a/src/block/block.json
+++ b/src/block/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 3,
   "name": "rrze/faubox",
-  "version": "0.0.1",
+  "version": "1.0.2",
   "title": "FAUbox",
   "category": "rrze",
   "icon": "cloud",


### PR DESCRIPTION
Addresses an issue in the download service where an empty root folder option could lead to incorrect path normalization, ensuring proper path validation and access control.

Updates the plugin version to 1.0.2 across all relevant files and bumps the tested up to WordPress version in `readme.txt`.