### PR TITLE
Registers FAUbox download REST endpoint

### DIFF
--- a/includes/API/DownloadService.php
+++ b/includes/API/DownloadService.php
@@ -77,7 +77,9 @@ class DownloadService
         header('X-Content-Type-Options: nosniff');
 
         try {
-            readfile($result['tmpfile']);
+            if ($request->get_method() !== 'HEAD') {
+                readfile($result['tmpfile']);
+            }
         } finally {
             @unlink($result['tmpfile']);
         }

--- a/includes/Rest/RestController.php
+++ b/includes/Rest/RestController.php
@@ -31,6 +31,36 @@ final class RestController
         $this->downloadService = $downloadService;
 
         add_action('rest_api_init', [$this, 'registerRoutes']);
+        add_filter(
+            'rrze_rest_api_public_endpoints',
+            [$this, 'registerPublicEndpoint']
+        );
+    }
+
+
+    /**
+     * Declare the signed download endpoint for access-control settings.
+     *
+     * Registration does not grant access. Network and private-site administrators
+     * decide independently whether the endpoint is available to visitors.
+     *
+     * @param mixed $endpoints Registered endpoint definitions.
+     * @return array Registered endpoint definitions including FAUbox downloads.
+     */
+    public function registerPublicEndpoint($endpoints): array
+    {
+        if (!is_array($endpoints)) {
+            $endpoints = [];
+        }
+
+        $endpoints['rrze-faubox-download'] = [
+            'label' => __('FAUbox signed downloads', 'rrze-faubox'),
+            'route' => '/rrze-faubox/v1/download',
+            'methods' => ['GET', 'HEAD'],
+            'description' => __('Allows visitors with a valid signed URL to download files.', 'rrze-faubox'),
+        ];
+
+        return $endpoints;
     }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rrze-faubox",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "index.js",
   "devDependencies": {

--- a/rrze-faubox.php
+++ b/rrze-faubox.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name:        RRZE FAUbox
  * Plugin URI:         https://github.com/RRZE-Webteam/rrze-faubox
- * Version:            1.0.2
+ * Version:            1.0.3
  * Description:        A Plugin for FAUbox data integration
  * Author:             RRZE Webteam
  * Author URI:         https://www.wp.rrze.fau.de/


### PR DESCRIPTION
Registers the FAUbox signed download REST API endpoint, allowing external settings plugins to manage its availability. This provides administrators with better control over access to signed downloads.

Enhances the download service by ensuring `HEAD` requests for downloads do not transfer file content, improving efficiency when only metadata is required.